### PR TITLE
Allow multi-byte string for key of Hash

### DIFF
--- a/lib/kori.rb
+++ b/lib/kori.rb
@@ -83,7 +83,6 @@ class Kori < Hash
   end
 
   def create_accessor_for(key, val)
-    return unless key.to_s =~ /^\w+\z/
     instance_variable_set("@#{key}", val)
     self.class.class_eval <<-EOCODE, __FILE__, __LINE__ + 1
       def #{key}

--- a/test/fixtures/kori.yml
+++ b/test/fixtures/kori.yml
@@ -8,3 +8,4 @@ c:
 e:
   f:
     g: 'zzz'
+日本語: 'Key is no problem even in multi-byte string'

--- a/test/fixtures/kori_on_rails.yml
+++ b/test/fixtures/kori_on_rails.yml
@@ -9,3 +9,4 @@ test:
   e:
     f:
       g: 'test_zzz'
+  日本語: 'Key is no problem even in multi-byte string'

--- a/test/kori_test.rb
+++ b/test/kori_test.rb
@@ -98,6 +98,14 @@ class KoriTest < Minitest::Test
     assert_equal 'zzz', KORI1.get('e.f.g')
     assert KORI1.e.f.g.frozen?
     assert KORI1.e.f.g.instance_of?(String)
+
+    assert_equal 'Key is no problem even in multi-byte string', KORI1.日本語
+    assert_equal 'Key is no problem even in multi-byte string', KORI1[:日本語]
+    assert_equal 'Key is no problem even in multi-byte string', KORI1['日本語']
+    assert_equal 'Key is no problem even in multi-byte string', KORI1.fetch('日本語')
+    assert_equal 'Key is no problem even in multi-byte string', KORI1.get('日本語')
+    assert KORI1.日本語.frozen?
+    assert KORI1.日本語.instance_of?(String)
   end
 
   def test_create_from_yaml
@@ -181,6 +189,14 @@ class KoriTest < Minitest::Test
     assert_equal 'zzz', KORI2.get('e.f.g')
     assert KORI2.e.f.g.frozen?
     assert KORI2.e.f.g.instance_of?(String)
+
+    assert_equal 'Key is no problem even in multi-byte string', KORI2.日本語
+    assert_equal 'Key is no problem even in multi-byte string', KORI2[:日本語]
+    assert_equal 'Key is no problem even in multi-byte string', KORI2['日本語']
+    assert_equal 'Key is no problem even in multi-byte string', KORI2.fetch('日本語')
+    assert_equal 'Key is no problem even in multi-byte string', KORI2.get('日本語')
+    assert KORI2.日本語.frozen?
+    assert KORI2.日本語.instance_of?(String)
   end
 
   def test_create_from_yaml_on_rails
@@ -264,5 +280,13 @@ class KoriTest < Minitest::Test
     assert_equal 'test_zzz', KORI3.get('e.f.g')
     assert KORI3.e.f.g.frozen?
     assert KORI3.e.f.g.instance_of?(String)
+
+    assert_equal 'Key is no problem even in multi-byte string', KORI3.日本語
+    assert_equal 'Key is no problem even in multi-byte string', KORI3[:日本語]
+    assert_equal 'Key is no problem even in multi-byte string', KORI3['日本語']
+    assert_equal 'Key is no problem even in multi-byte string', KORI3.fetch('日本語')
+    assert_equal 'Key is no problem even in multi-byte string', KORI3.get('日本語')
+    assert KORI3.日本語.frozen?
+    assert KORI3.日本語.instance_of?(String)
   end
 end

--- a/test/support/kori_creator.rb
+++ b/test/support/kori_creator.rb
@@ -17,7 +17,8 @@ class KoriCreator
           f: {
             g: 'zzz'
           }
-        }
+        },
+        日本語: 'Key is no problem even in multi-byte string'
       }
       Kori.create(hash)
     end


### PR DESCRIPTION
Be able to use multi-byte string for key of Hash.
